### PR TITLE
Enhance column configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,17 @@
-
 import streamlit as st
 import pandas as pd
 import os
+import json
 from streamlit_elements import elements, mui, dashboard, sync
 
 DATA_FILE = "data/board.csv"
+COLUMNS_FILE = "data/columns.json"
+DEFAULT_COLUMNS = [
+    "new project/feature",
+    "being built",
+    "in testing",
+    "deployed",
+]
 
 if not os.path.exists("data"):
     os.makedirs("data")
@@ -13,22 +20,50 @@ if not os.path.isfile(DATA_FILE):
     df = pd.DataFrame(columns=['Feature', 'Status', 'Votes', 'Comments'])
     df.to_csv(DATA_FILE, index=False)
 
+if not os.path.isfile(COLUMNS_FILE):
+    with open(COLUMNS_FILE, "w") as f:
+        json.dump(DEFAULT_COLUMNS, f)
+
 df = pd.read_csv(DATA_FILE)
+with open(COLUMNS_FILE) as f:
+    column_list = json.load(f)
 
 st.set_page_config(layout="wide")
 st.title("Trello-like Project Management")
 
-columns = st.sidebar.text_input("Columns", "new project/feature,being built,in testing,deployed")
-column_list = [col.strip() for col in columns.split(",")]
+columns_input = st.sidebar.text_input("Columns (comma separated)", ",".join(column_list))
+if st.sidebar.button("Update Columns"):
+    column_list = [c.strip() for c in columns_input.split(",") if c.strip()]
+    if column_list:
+        with open(COLUMNS_FILE, "w") as f:
+            json.dump(column_list, f)
+        df.loc[~df["Status"].isin(column_list), "Status"] = column_list[0]
+        df.to_csv(DATA_FILE, index=False)
 
 st.sidebar.header("Add New Feature")
 new_feature = st.sidebar.text_input("Feature Name")
 if st.sidebar.button("Add Feature") and new_feature:
-    df = pd.concat([df, pd.DataFrame({'Feature': [new_feature], 'Status': [column_list[0]], 'Votes': [0], 'Comments': [""]})])
+    default_status = column_list[0] if column_list else ""
+    df = pd.concat([
+        df,
+        pd.DataFrame(
+            {
+                'Feature': [new_feature],
+                'Status': [default_status],
+                'Votes': [0],
+                'Comments': [""],
+            }
+        ),
+    ])
     df.to_csv(DATA_FILE, index=False)
 
 with elements("dashboard"):
-    with dashboard.Grid(layout=[{"i": col, "x": idx, "y": 0, "w": 1, "h": 10} for idx, col in enumerate(column_list)], draggableHandle=".draggable"):
+    col_width = max(1, 12 // len(column_list)) if column_list else 12
+    layout = [
+        {"i": col, "x": idx * col_width, "y": 0, "w": col_width, "h": 10}
+        for idx, col in enumerate(column_list)
+    ]
+    with dashboard.Grid(layout=layout, draggableHandle=".draggable"):
         for col in column_list:
             with mui.Paper(key=col, elevation=3, style={"padding": "1rem", "overflowY": "auto"}):
                 mui.Typography(col, variant="h6", className="draggable")
@@ -39,3 +74,4 @@ with elements("dashboard"):
                             mui.Typography(row['Feature'], variant="body2"),
                             mui.Button(f"Votes: {row['Votes']}", variant="outlined", size="small")
                         )
+        sync()

--- a/data/columns.json
+++ b/data/columns.json
@@ -1,0 +1,1 @@
+["new project/feature", "being built", "in testing", "deployed"]


### PR DESCRIPTION
## Summary
- add JSON file to store column names
- allow editing columns via sidebar input
- ensure columns fill the page using grid width calculation
- move out-of-scope features to first column when updating columns
- tidy up formatting and add `sync()` call

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6843501509648324a51539c6114e252a