### PR TITLE
Add editable columns and drag-and-drop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 streamlit
 pandas
-streamlit-elements
+streamlit-sortables


### PR DESCRIPTION
## Summary
- switch from `streamlit-elements` to `streamlit-sortables`
- persist dataframe and columns using session state
- allow column titles to be edited from within the app
- move features between columns via drag-and-drop

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684351a67878832489fc490103a9c2e7